### PR TITLE
Upgrade to PIO 0.11.0, Scala 2.11, & Spark 2.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,12 +2,13 @@ name := "template-scala-parallel-classification"
 
 organization := "org.apache.predictionio"
 
-scalaVersion := "2.10.5"
+scalaVersion := "2.11.8"
 
 libraryDependencies ++= Seq(
-  "org.apache.predictionio" %% "apache-predictionio-core" % "0.10.0-incubating" % "provided",
-  "org.apache.spark"        %% "spark-core"               % "1.4.1" % "provided",
-  "org.apache.spark"        %% "spark-mllib"              % "1.4.1" % "provided",
+  "org.apache.predictionio" %% "apache-predictionio-core" % "0.11.0-incubating" % "provided",
+  "org.apache.spark"        %% "spark-core"               % "2.1.0" % "provided",
+  "org.apache.spark"        %% "spark-mllib"              % "2.1.0" % "provided",
   "org.scalatest"           %% "scalatest"                % "2.2.1" % "test")
 
 parallelExecution in Test := false
+test in assembly := {}

--- a/template.json
+++ b/template.json
@@ -1,1 +1,1 @@
-{"pio": {"version": { "min": "0.10.0-incubating" }}}
+{"pio": {"version": { "min": "0.11.0-incubating" }}}


### PR DESCRIPTION
🚧 **Do not merge** until PredictionIO 0.11.0-incubating is released. 🚧